### PR TITLE
商品詳細ページ（サーバーサイド）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,12 +39,14 @@ gem 'bootsnap', '>= 1.1.0', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-
+  
   gem 'capistrano'
   gem 'capistrano-rbenv'
   gem 'capistrano-bundler'
   gem 'capistrano-rails'
   gem 'capistrano3-unicorn'
+
+  gem 'pry-byebug'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,6 +202,9 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.8.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.3)
@@ -331,6 +334,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4, < 0.6.0)
+  pry-byebug
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.4, >= 5.2.4.1)

--- a/app/assets/stylesheets/items/show.scss
+++ b/app/assets/stylesheets/items/show.scss
@@ -49,6 +49,11 @@
       .detail_table{
         margin-bottom:20px;
         font-family: Arial, Helvetica, sans-serif;
+        &--group{
+          table{
+            margin:  0 auto;
+          }
+        }
       }
         table, td, th {
           border: 1px solid #595959;
@@ -85,11 +90,41 @@
       font-family: Arial, Helvetica, sans-serif;
       margin-top: 40px;
     }
-  
+
+    .l-single-container{
+      width: 700px;
+      margin: 0 auto;
+      .listing-item-change-box{
+        margin: 24px 0 24px 0;
+        background: #fff;
+        padding: 8px 16px 8px 16px;
+        text-align: center;
+        .btn-default{
+          margin: 16px 0 16px 0;
+        }
+        a{
+          background: #ea352d;
+          border: 1px solid #ea352d;
+          color: #fff;
+
+          display: block;
+          width: 100%;
+          line-height: 48px;
+          font-size: 14px;
+          border: 1px solid transparent;
+          -webkit-transition: all ease-out .3s;
+          transition: all ease-out .3s;
+          cursor: pointer;
+          text-align: center;
+        }
+      }
+    }
+
   .detail_footer{
     background-color:lavender;
     height:500px;
   }
+
   .detail_footer{
     background-color: #272727;
   }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,11 @@ class ItemsController < ApplicationController
   def new
     @item = Item.new
   end
+
+
   def show
     @item = Item.find(params[:id])
+    @user = User.find(params[:id])
   end
+
 end

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,5 +1,6 @@
 class TopController < ApplicationController
 
   def index
+    @items = Item.limit(10).order('created_at DESC')
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,5 @@
 class Item < ApplicationRecord
-  # belongs_to user, foreign_key: 'user_id'
+  belongs_to :user, foreign_key: 'user_id'
   belongs_to :category
+  has_many :item_images
 end

--- a/app/models/item_image.rb
+++ b/app/models/item_image.rb
@@ -1,2 +1,4 @@
 class ItemImage < ApplicationRecord
+
+  belongs_to :item
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -10,10 +10,11 @@
     - @item.item_images.each do |image|
       .detail_content_main_box-image
         .main__image
-          %img{:alt => "ライオンの画像", :border => "0", :height =>"100", :src=>"https://www.homepage-tukurikata.com/image/lion.jpg", :width => "150"}/
+          = link_to image_tag("https://www.homepage-tukurikata.com/image/lion.jpg", class:"link-icon.abtn"),"#"
+          %image_tag{:alt => "ライオンの画像", :border => "0", :height =>"100", :src=>"https://www.homepage-tukurikata.com/image/lion.jpg", :width => "150"}/
         .detail_content_main_box-subimage1
-          %img{:alt => "ライオンの画像", :border => "0", :height =>"100", :src=>"https://www.homepage-tukurikata.com/image/lion.jpg", :width => "150"}/
-          %img{:alt => "ライオンの画像", :border => "0", :height =>"100", :src=>"https://www.homepage-tukurikata.com/image/lion.jpg", :width => "150"}/
+          = link_to image_tag("https://www.homepage-tukurikata.com/image/lion.jpg", class:"link-icon"),"#"
+          = link_to image_tag("https://www.homepage-tukurikata.com/image/lion.jpg", class:"link-icon.gbtn"),"#"
       %br
       .detail_content_main_box-price
         .detail_content_main_price

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -5,47 +5,63 @@
     .detail_header_main FURIMA>ベビー・キッズ>ベビー服(男女兼用)> ~95cmアウター >product3
   .detail_content
     .detail_content_main_box
-      .detail_content_main_box-name 商品名
+      .detail_content_main_box-name
+        = @item.name
+    - @item.item_images.each do |image|
       .detail_content_main_box-image
-        %img{:alt => "ライオンの画像", :border => "0", :height => "350", :src => "https://www.homepage-tukurikata.com/image/lion.jpg", :width => "500"}/
-      .detail_content_main_box-subimage1
-        %img{:alt => "ライオンの画像", :border => "0", :height =>"100", :src=>"https://www.homepage-tukurikata.com/image/lion.jpg", :width => "150"}/
-        %img{:alt => "ライオンの画像", :border => "0", :height =>"100", :src=>"https://www.homepage-tukurikata.com/image/lion.jpg", :width => "150"}/
+        .main__image
+          %img{:alt => "ライオンの画像", :border => "0", :height =>"100", :src=>"https://www.homepage-tukurikata.com/image/lion.jpg", :width => "150"}/
+        .detail_content_main_box-subimage1
+          %img{:alt => "ライオンの画像", :border => "0", :height =>"100", :src=>"https://www.homepage-tukurikata.com/image/lion.jpg", :width => "150"}/
+          %img{:alt => "ライオンの画像", :border => "0", :height =>"100", :src=>"https://www.homepage-tukurikata.com/image/lion.jpg", :width => "150"}/
       %br
       .detail_content_main_box-price
-        .detail_content_main_price ￥3,000
+        .detail_content_main_price
+          ￥
+          = @item.price
         .detail_content_main_tax (税込)送料込み
       %br
       .detail_content_main_name 商品名
-      .detail_table
+    .detail_table
+      .detail_table--group
         %table
           %tbody
             %tr
               %td 出品者
-              %td 井口
-            %tr
-              %td カテゴリ
-              %td 人間
-            %tr
-              %td ブランド
-              %td 男
+              %td
+                = @user.nickname
+          - if @item.size.present?
             %tr
               %td 商品のサイズ
-              %td XL
+              %td
+                = @item.size
             %tr
               %td 商品の状態
-              %td 子供嫌い
+              %td
+                = @item.delivery_method
             %tr
               %td 配送料の負担
               %td 送料別（購入者負担）
             %tr
               %td 配送元の地域
-              %td 神奈川県
+              %td
+                = @item.area
             %tr
               %td 発送日の目安
-              %td 1年後
+              %td
+                = @item.delivery_date
     .detail_content_link
       %p < 前の商品
       %p > 次の商品
+
+    - if @item.id == @user.id
+      .l-single-container
+        .listing-item-change-box
+          = link_to "商品の編集", class:'btn-default btn-red'
+          %p.text-center
+            or
+          =link_to "削除"
+          - if @item.id != @user.id
+            =link_to "購入", new_item_path(@item.id),class:'btn-default btn-gray'
   .detail_footer
     = render './footer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,11 @@
 Rails.application.routes.draw do
 
   root to: "top#index"
+  resources :items, only: [:new, :show,:destroy]
   devise_for :users, :controllers => {
     :registrations => 'users/registrations',
   :sessions => 'users/sessions'
   }
-  resources :items, only: [:new, :show]
   resources :users, only: [:new]
 
     devise_scope :user do


### PR DESCRIPTION
# what
商品詳細ページのサーバーサイドを実装。
1.出品者自身は商品詳細画面から購入画面に遷移できないようになっている
2. 出品者自身は商品詳細画面から商品情報の編集や、商品情報の削除に遷移できるようになっている

# why
1.出品者は購入ページに遷移する必要がない為。
2.出品者以外が編集、削除が行えない様にする為。