### PR TITLE
詳細ページの遷移先のパスを変更

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,7 +1,7 @@
 .detail
   .detail_header
     .detail_header_top
-      = render './header'
+      = render 'share/header'
   .detail_content
     .detail_content_main_box
       .detail_content_main_box-name


### PR DESCRIPTION
# what
遷移先のパスを変更

# wht
パスがうまく指定されておらず、エラーが発生していた為。